### PR TITLE
Add JSON collector

### DIFF
--- a/EventsCollectors/JSONEventsCollector.py
+++ b/EventsCollectors/JSONEventsCollector.py
@@ -36,6 +36,10 @@ class JSONEventsCollector(EventsCollector):
                 "description": "The name of the community",
                 "type": "string"
             },
+            "community_description": {
+                "description": "The description of the community",
+                "type": "string"
+            },
             "events_url":{
                 "description":"The URL to get events from",
                 "type": "string"
@@ -48,7 +52,6 @@ class JSONEventsCollector(EventsCollector):
         "required":[
             "community_name",
             "events_url",
-            "tags"
         ]
     }
 

--- a/EventsCollectors/JSONEventsCollector.py
+++ b/EventsCollectors/JSONEventsCollector.py
@@ -1,6 +1,5 @@
 import os
 import toml
-import pytz
 import requests
 import json
 from dateutil.parser import parse

--- a/EventsCollectors/JSONEventsCollector.py
+++ b/EventsCollectors/JSONEventsCollector.py
@@ -108,7 +108,12 @@ class JSONEventsCollector(EventsCollector):
         for bot_config in getattr(self.config.BOTS, self.name, []):
             
             community_name = bot_config['community_name']
-            community_tags = bot_config['tags']
+
+            try:
+                community_tags = bot_config['tags']
+            except KeyError: # if no tags are specified, make them nothing
+                community_tags = []
+            
             self.logger.info(f"Processing events for {community_name} with events_url {bot_config['events_url']}")
 
             try:

--- a/EventsCollectors/JSONEventsCollector.py
+++ b/EventsCollectors/JSONEventsCollector.py
@@ -1,0 +1,136 @@
+import os
+import toml
+import pytz
+import requests
+import json
+from dateutil.parser import parse
+
+from disnake.ext import commands
+
+from ._base import EventsCollector
+
+### JSON Events collector
+
+# Minimum required values:
+# name: The name of the event
+# description: The description of the event
+# start_time: The start time of the event in the ISO format (UTC timezone) 
+# end_time: The end time of the event in the ISO format (UTC timezone) 
+# location: The location of the event
+
+# Example config:
+# [[BOTS.JSONEventsCollector]]
+# community_name = "Example Name"
+# community_description = "Example Description"
+# events_url = "https://example.com/events_json"
+# tags = ['example']
+
+
+class JSONEventsCollector(EventsCollector):
+    jschema = {
+        "$schema":"http://json-schema.org/draft-04/schema#",
+        "title":"JsonEventsConfig",
+        "description":"Config for JSON collector",
+        "type":"object",
+        "properties":{
+            "community_name": {
+                "description": "The name of the community",
+                "type": "string"
+            },
+            "events_url":{
+                "description":"The URL to get events from",
+                "type": "string"
+            },
+            "tags":{
+                "description":"A list of tags",
+                "type": "array"
+            }
+        },
+        "required":[
+            "community_name",
+            "events_url",
+            "tags"
+        ]
+    }
+
+    def __init__(self, bot, config, sched, dclient, rclient):
+        super().__init__(bot, config, sched, dclient, rclient)
+
+        if not self.valide_config:
+            return
+        
+        for bot_config in getattr(self.config.BOTS, self.name, []):
+            self.logger.info(f"Bot config: {bot_config}")
+
+    def format_event(self, event, api_ver, community_name, community_tags):
+        name = event['name']
+        community_name = community_name
+        start_time = event['start_time']
+        end_time = event['end_time']
+        location = event['location']
+        location_web_session_url = ''
+        location_session_url = ''
+        tags = "`".join(community_tags)
+        description = event['description']
+        if api_ver == 1:
+            event = self.sformat(
+                title = name,
+                description = description,
+                location_str = location,
+                start_time = start_time,
+                end_time = end_time,
+                community_name = community_name,
+                api_ver = 1
+            )
+        if api_ver == 2:
+            session_image = ''
+            event = self.sformat(
+                title = name,
+                description = description,
+                session_image = session_image,
+                location_str = location,
+                location_web_session_url = location_web_session_url,
+                location_session_url = location_session_url,
+                start_time = start_time,
+                end_time = end_time,
+                community_name = community_name,
+                tags = tags,
+                community_url = "",
+                api_ver = 2
+            )
+        return event
+
+    def get_data(self, dclient):
+        self.logger.info(f'Update {self.name} events collector')
+
+        for bot_config in getattr(self.config.BOTS, self.name, []):
+            
+            community_name = bot_config['community_name']
+            community_tags = bot_config['tags']
+            self.logger.info(f"Processing events for {community_name} with events_url {bot_config['events_url']}")
+
+            try:
+                response = requests.get(
+                    bot_config['events_url']
+                )
+            except:
+                # If the request fails, catch it.
+                self.logger.error(f"Exception on request for {community_name}")
+                continue
+
+            # If we didn't get a 200, just skip it.
+            if response.status_code != 200:
+                self.logger.error(f"Got {response.status_code} from {community_name}, expecting 200. Skipping")
+                continue
+
+            events_json = json.loads(response.text)
+
+            _events_v1 = []
+            _events_v2 = []
+
+            for event in events_json:
+                _events_v1.append(self.format_event(event, api_ver=1, community_name=community_name, community_tags=community_tags))
+                _events_v2.append(self.format_event(event, api_ver=2, community_name=community_name, community_tags=community_tags))
+
+            self.rclient.write('events_v1', _events_v1, api_ver=1, current_communities=community_name)
+            self.rclient.write('events_v2', _events_v2, api_ver=2, current_communities=community_name)

--- a/EventsCollectors/__init__.py
+++ b/EventsCollectors/__init__.py
@@ -2,5 +2,6 @@ from .ExternalEventsCollector import ExternalEventsCollector
 from .DiscordEventsCollector import DiscordEventsCollector
 from .GoogleCalendarEventsCollector import GoogleCalendarEventsCollector
 from .ApolloEventsCollector import ApolloEventsCollector
+from .JSONEventsCollector import JSONEventsCollector
 
-__all__ = [ExternalEventsCollector, DiscordEventsCollector, GoogleCalendarEventsCollector, ApolloEventsCollector]
+__all__ = [ExternalEventsCollector, DiscordEventsCollector, GoogleCalendarEventsCollector, ApolloEventsCollector, JSONEventsCollector]

--- a/README.md
+++ b/README.md
@@ -112,11 +112,12 @@ For config, you need to use the key `[[BOTS.JSONEventsCollector]]` and have the 
 
 - `community_name`: str, The community name
 - `events_url`: str, The URL to get events from
-- `tags`: list, the list of tags for the community
 
 
 You can also add
-- `community_description`: str, The description of the community (optional)
+
+- `community_description`: str, The description of the community
+- `tags`: array, community tags
 
 
 Required keys in the JSON response:

--- a/README.md
+++ b/README.md
@@ -104,6 +104,60 @@ guild_channel = "events"
 bot = xxxxxxxxxxxxxxxxxx
 ```
 
+### JSON
+
+Fetches events from JSON over http.
+
+For config, you need to use the key `[[BOTS.JSONEventsCollector]]` and have the following keys:
+
+- `community_name`: str, The community name
+- `events_url`: str, The URL to get events from
+- `tags`: list, the list of tags for the community
+
+
+You can also add
+- `community_description`: str, The description of the community (optional)
+
+
+Required keys in the JSON response:
+
+- `name`: The name of the event
+- `description`: The event description
+- `start_time`: The start time of the event in an ISO timestamp (must be in UTC)
+- `end_time`: The end time of the event in an ISO timestamp (must be in UTC)
+- `location`: The location of the event
+
+
+#### Example config / response
+
+An example config to be put in `config.toml`:
+
+```
+[[BOTS.JSONEventsCollector]]
+community_name = "Example Name"
+community_description = "Example Description"
+events_url = "https://example.com/events_json"
+tags = ['example']
+```
+
+
+An example response from the endpoint:
+
+
+```
+[
+  {
+    "name": "Example Name",
+    "description": "Example description",
+    "location": "BigRedWolfy's session",
+    "start_time": "2024-04-20T00:00:00+00:00",
+    "end_time": "2024-04-20T02:00:00+00:00"
+  }
+]
+```
+
+
+
 ### TwitchStreamsCollector
 
 This tools also give the ability to list planned Resonite streams from a

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ An example response from the endpoint:
   {
     "name": "Example Name",
     "description": "Example description",
-    "location": "BigRedWolfy's session",
+    "location": "Example's session",
     "start_time": "2024-04-20T00:00:00+00:00",
     "end_time": "2024-04-20T02:00:00+00:00"
   }

--- a/StreamsCollectors/TwitchStreamsCollector.py
+++ b/StreamsCollectors/TwitchStreamsCollector.py
@@ -37,6 +37,9 @@ class TwitchStreamsCollector(StreamsCollector):
         # Update streams collector
         str_streams = []
         streams = self.tclient.get_schedules()
+        if not streams:
+            self.logger.info("We have no streams! Skip!")
+            return
         for stream in streams:
             str_streams.append(f"{separator[2]['field']}".join(stream))
         streams = f"{separator[2]['event']}".join(s for s in str_streams if s)

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,8 @@
     <!-- Bulma Version 0.9.0-->
     <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css'>
     <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/1.9.1/css/OverlayScrollbars.min.css'>
-    <link rel='stylesheet' href='https://kingsora.github.io/OverlayScrollbars/etc/os-theme-thin-dark.css'>
+    <!--<link rel='stylesheet' href='https://kingsora.github.io/OverlayScrollbars/etc/os-theme-thin-dark.css'>-->
+    <link rel='stylesheet' href='https://raw.githubusercontent.com/KingSora/OverlayScrollbars/master/docs/v1/etc/os-theme-thin-dark.css'>
     <link rel='stylesheet' href="../css/prism.css">
     <link rel="stylesheet" href="../css/cheatsheet.css">
     <script src="https://kit.fontawesome.com/7dc3015a44.js" crossorigin="anonymous"></script>

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,7 +12,8 @@
     <!-- Bulma Version 0.9.0-->
     <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css'>
     <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/overlayscrollbars/1.9.1/css/OverlayScrollbars.min.css'>
-    <link rel='stylesheet' href='https://kingsora.github.io/OverlayScrollbars/etc/os-theme-thin-dark.css'>
+    <!--<link rel='stylesheet' href='https://kingsora.github.io/OverlayScrollbars/etc/os-theme-thin-dark.css'>-->
+    <link rel='stylesheet' href='https://raw.githubusercontent.com/KingSora/OverlayScrollbars/master/docs/v1/etc/os-theme-thin-dark.css'>
     <link rel='stylesheet' href="../css/prism.css">
     <link rel="stylesheet" href="../css/cheatsheet.css">
     <script src="https://kit.fontawesome.com/7dc3015a44.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
This pull request adds a collector for events listed in a JSON response on a webserver. This has mainly been done in order to add Mentor Workshop sessions to the events facet as that has been requested by Mentors in the Mentor Discord, and work was already in progress to create a facet for Mentor Workshop events.

Example configuration is included in EventsCollectors/JSONEventsCollector.py

This PR has the side effect of letting the app launch without Twitch being configured & fixes a dead link to a stylesheet.

For testing this, the Mentor Workshop sessions list can be found at https://workshops.voxelbone.cloud/events_json - this is currently mostly test data but will be the actual mentor workshop data soon as some stuff is worked out on our end.